### PR TITLE
Fix issues with python paths in workflow

### DIFF
--- a/.github/workflows/update_build.yml
+++ b/.github/workflows/update_build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==1.8.5"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/update_build.yml
+++ b/.github/workflows/update_build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install "poetry==1.8.5"
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/update_build.yml
+++ b/.github/workflows/update_build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry==2.1.1"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/scripts/generate_nightly/generate_nightly/__main__.py
+++ b/scripts/generate_nightly/generate_nightly/__main__.py
@@ -7,11 +7,11 @@ from typing import Any, Dict, List
 
 from .template.template import Template
 
-PATH_JOB_TEMPLATE = Path("template/job_template.yml")
-PATH_NIGHTLY_TEMPLATE = Path("template/nightly_template.yml")
-PATH_CUSTOM_JOBS_TEMPLATE = Path("template/custom_jobs_template.yml")
-PATH_FORCE_REBUILD_TEMPLATE = Path("template/force_rebuild_template.yml")
-PATH_NIGHTLY = Path(".github/workflows/nightly.yml")
+PATH_JOB_TEMPLATE = Path("../../template/job_template.yml")
+PATH_NIGHTLY_TEMPLATE = Path("../../template/nightly_template.yml")
+PATH_CUSTOM_JOBS_TEMPLATE = Path("../../template/custom_jobs_template.yml")
+PATH_FORCE_REBUILD_TEMPLATE = Path("../../template/force_rebuild_template.yml")
+PATH_NIGHTLY = Path("../../.github/workflows/nightly.yml")
 
 
 def main():


### PR DESCRIPTION
This PR fixes the errors that started to occur on January 6th of this year. On the same day, a new version for `poetry` the python build tool that is used was released with the following change:
> Actually switch the directory when using --directory/-C 

This functionality was used during build.

This PR sets the correct paths for the template after the change and freezes the used version of `poetry` so it does not break in the future