### PR TITLE
Fix dependency graph by ignoring Retriever-UpdateSite

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,8 +34,9 @@ jobs:
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
     - Palladio-QuAL-MonitorRepository
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-EMFProfiles
     - set-force-build
     if: success() || failure()
@@ -56,8 +57,8 @@ jobs:
           "PalladioSimulator/Palladio-Analyzer-SimuCom", "PalladioSimulator/Palladio-Analyzer-SimuLizar",
           "PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-MonitorRepository",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addon-ArchitecturalTemplates build.yml
   Palladio-Addon-ArchitecturalTemplates-LoadBalancing:
@@ -69,8 +70,8 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -89,7 +90,7 @@ jobs:
           "PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-SimuCom",
           "PalladioSimulator/Palladio-Analyzer-SimuLizar", "PalladioSimulator/Palladio-Core-Commons",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine"]'
+          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addon-ArchitecturalTemplates-LoadBalancing
         build.yml
@@ -100,10 +101,11 @@ jobs:
     - Palladio-Analyzer-SimuLizar
     - Palladio-Core-PCM
     - Palladio-QuAL-ProbeFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-EMFProfiles
     - set-force-build
     if: success() || failure()
@@ -121,14 +123,14 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-SimuCom",
           "PalladioSimulator/Palladio-Analyzer-SimuLizar", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-QuAL-ProbeFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
+          "PalladioSimulator/Palladio-QuAL-ProbeFramework", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
+          "PalladioSimulator/Palladio-Simulation-Scheduler", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-CostEfficiency build.yml
   Palladio-Addons-EnvironmentalDynamics:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Supporting-MDSDProfiles
     - Palladio-ThirdParty-EMFProfiles
     - set-force-build
@@ -145,8 +147,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-EnvironmentalDynamics build.yml
   Palladio-Addons-ExperimentAutomation:
@@ -163,7 +164,8 @@ jobs:
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-MonitorRepository
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-CloudScaleUsageEvolution
     - Palladio-ThirdParty-LIMBO
     - Palladio-ThirdParty-Library
@@ -187,9 +189,9 @@ jobs:
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
           "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-QuAL-MonitorRepository",
-          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution", "PalladioSimulator/Palladio-ThirdParty-LIMBO",
-          "PalladioSimulator/Palladio-ThirdParty-Library"]'
+          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution",
+          "PalladioSimulator/Palladio-ThirdParty-LIMBO", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-ExperimentAutomation build.yml
   Palladio-Addons-FailureScenario:
@@ -201,7 +203,6 @@ jobs:
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
     - Palladio-Editors-Tree
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - set-force-build
     if: success() || failure()
@@ -220,15 +221,13 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-SimuCom",
           "PalladioSimulator/Palladio-Analyzer-SimuLizar", "PalladioSimulator/Palladio-Core-Commons",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
-          "PalladioSimulator/Palladio-Editors-Tree", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine"]'
+          "PalladioSimulator/Palladio-Editors-Tree", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-FailureScenario build.yml
   Palladio-Addons-FluentApiModelGenerator:
     needs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -243,8 +242,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-FluentApiModelGenerator
         build.yml
@@ -266,10 +264,11 @@ jobs:
     - Palladio-QuAL-MonitorRepository
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-CloudScaleUsageEvolution
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-Library
@@ -296,11 +295,11 @@ jobs:
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-ExperimentAnalysis",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
-          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
+          "PalladioSimulator/Palladio-Simulation-Scheduler", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-Indirections build.yml
   Palladio-Addons-MeasurementsUI:
@@ -313,7 +312,7 @@ jobs:
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MonitorRepository
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-WorkflowEngine
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -332,7 +331,7 @@ jobs:
           "PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-SimuLizar",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
-          "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-MeasurementsUI build.yml
   Palladio-Addons-PerOpteryx:
@@ -349,10 +348,11 @@ jobs:
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-RecorderFramework
     - Palladio-QuAL-SensorFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-FeatureModel
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
@@ -376,17 +376,16 @@ jobs:
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-QuAL-SensorFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
+          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-Supporting-FeatureModel", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-PerOpteryx build.yml
   Palladio-Addons-PlantUML:
     needs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -401,8 +400,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-PlantUML build.yml
   Palladio-Addons-Power:
@@ -414,7 +412,6 @@ jobs:
     - Palladio-QuAL-ExperimentAnalysis
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-ThirdParty-LIMBO
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
@@ -435,9 +432,8 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-ExperimentAnalysis", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
-          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-LIMBO", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ThirdParty-LIMBO",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-Power build.yml
   Palladio-Addons-SPD-Metamodel:
@@ -447,7 +443,6 @@ jobs:
     - Palladio-Editors-Commons
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -464,7 +459,7 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
-          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-QuAL-MetricSpecification"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-SPD-Metamodel build.yml
   Palladio-Addons-ServiceLevelObjectives:
@@ -476,7 +471,7 @@ jobs:
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-MonitorRepository
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
     - set-force-build
@@ -496,7 +491,7 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+          "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-ServiceLevelObjectives
@@ -507,9 +502,10 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-QuAL-ProbeFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
+    - Palladio-Supporting-Branding
+    - Palladio-Supporting-WorkflowEngine
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -526,8 +522,8 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Analyzer-SimuCom", "PalladioSimulator/Palladio-Core-Commons",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
-          "PalladioSimulator/Palladio-Simulation-Scheduler"]'
+          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-SimuComExactSchedulers
         build.yml
@@ -536,7 +532,6 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -552,7 +547,7 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-Editors-Commons"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Addons-Vulnerability-Metamodel
         build.yml
@@ -568,8 +563,8 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-Library
     - set-force-build
@@ -591,8 +586,8 @@ jobs:
           "PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-Reliability",
           "PalladioSimulator/Palladio-Analyzer-SimuCom", "PalladioSimulator/Palladio-Analyzer-Solver",
           "PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
+          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
           "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-Dependability-ML build.yml
@@ -601,8 +596,9 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-FeatureModel
+    - Palladio-Supporting-WorkflowEngine
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -618,8 +614,8 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Supporting-FeatureModel"]'
+          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-FeatureModel", "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-Framework build.yml
   Palladio-Analyzer-ProtoCom:
@@ -630,8 +626,9 @@ jobs:
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
     - Palladio-QuAL-SensorFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
@@ -652,9 +649,9 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Analyzer-SimuCom",
           "PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-SensorFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-ProtoCom build.yml
   Palladio-Analyzer-Reliability:
@@ -667,7 +664,8 @@ jobs:
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-ProbeFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
     - set-force-build
@@ -688,8 +686,8 @@ jobs:
           "PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
           "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-Reliability build.yml
   Palladio-Analyzer-SimExp:
@@ -716,12 +714,12 @@ jobs:
     - Palladio-QuAL-MonitorRepository
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
     - Palladio-Supporting-Branding
     - Palladio-Supporting-FeatureModel
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-CloudScaleUsageEvolution
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-LIMBO
@@ -752,10 +750,10 @@ jobs:
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-ExperimentAnalysis",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
-          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
-          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-FeatureModel",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution",
+          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
+          "PalladioSimulator/Palladio-Simulation-Scheduler", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-FeatureModel", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine", "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution",
           "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-LIMBO",
           "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
@@ -773,10 +771,11 @@ jobs:
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-RecorderFramework
     - Palladio-QuAL-SensorFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-FeatureModel
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
     - set-force-build
@@ -798,10 +797,10 @@ jobs:
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-ProbeFramework", "PalladioSimulator/Palladio-QuAL-RecorderFramework",
-          "PalladioSimulator/Palladio-QuAL-SensorFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
-          "PalladioSimulator/Palladio-Supporting-FeatureModel", "PalladioSimulator/Palladio-ThirdParty-Library",
-          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-QuAL-SensorFramework", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
+          "PalladioSimulator/Palladio-Simulation-Scheduler", "PalladioSimulator/Palladio-Supporting-Branding",
+          "PalladioSimulator/Palladio-Supporting-FeatureModel", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-SimuCom build.yml
   Palladio-Analyzer-SimuLizar:
@@ -819,11 +818,12 @@ jobs:
     - Palladio-QuAL-MonitorRepository
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-Simulation-AbstractSimEngine
     - Palladio-Simulation-Scheduler
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-FeatureModel
     - Palladio-Supporting-MDSDProfiles
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-CloudScaleUsageEvolution
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-LIMBO
@@ -850,11 +850,12 @@ jobs:
           "PalladioSimulator/Palladio-QuAL-ExperimentAnalysis", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
           "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-QuAL-MonitorRepository",
           "PalladioSimulator/Palladio-QuAL-ProbeFramework", "PalladioSimulator/Palladio-QuAL-RecorderFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine",
-          "PalladioSimulator/Palladio-Simulation-Scheduler", "PalladioSimulator/Palladio-Supporting-FeatureModel",
-          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-LIMBO",
-          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-FeatureModel",
+          "PalladioSimulator/Palladio-Supporting-MDSDProfiles", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution", "PalladioSimulator/Palladio-ThirdParty-EMFProfiles",
+          "PalladioSimulator/Palladio-ThirdParty-LIMBO", "PalladioSimulator/Palladio-ThirdParty-Library",
+          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-SimuLizar build.yml
   Palladio-Analyzer-Slingshot:
@@ -870,7 +871,7 @@ jobs:
     - Palladio-QuAL-MonitorRepository
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-CloudScaleUsageEvolution
     - Palladio-ThirdParty-LIMBO
     - Palladio-ThirdParty-Library
@@ -893,7 +894,7 @@ jobs:
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
-          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
           "PalladioSimulator/Palladio-ThirdParty-CloudScaleUsageEvolution", "PalladioSimulator/Palladio-ThirdParty-LIMBO",
           "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
@@ -904,7 +905,8 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
+    - Palladio-Supporting-WorkflowEngine
     - Palladio-ThirdParty-Wrapper
     - set-force-build
     if: success() || failure()
@@ -922,7 +924,8 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Analyzer-Framework", "PalladioSimulator/Palladio-Core-Commons",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Editors-Commons",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Analyzer-Solver build.yml
   Palladio-Bench-Product:
@@ -969,7 +972,6 @@ jobs:
     - Palladio-QuAL-SensorFramework
     - Palladio-ReverseEngineering-Retriever
     - Palladio-ReverseEngineering-Retriever-Services
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-ReverseEngineering-Retriever-Vulnerability
     - Palladio-ReverseEngineering-SoMoX
     - Palladio-ReverseEngineering-SoMoX-SEFF
@@ -1022,7 +1024,7 @@ jobs:
           "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
           "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-QuAL-SensorFramework",
           "PalladioSimulator/Palladio-ReverseEngineering-Retriever", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Services",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Vulnerability",
+          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Vulnerability",
           "PalladioSimulator/Palladio-ReverseEngineering-SoMoX", "PalladioSimulator/Palladio-ReverseEngineering-SoMoX-SEFF",
           "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
           "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-EMFProfilesEditor",
@@ -1077,7 +1079,6 @@ jobs:
     - Palladio-QuAL-SensorFramework
     - Palladio-ReverseEngineering-Retriever
     - Palladio-ReverseEngineering-Retriever-Services
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-ReverseEngineering-Retriever-Vulnerability
     - Palladio-ReverseEngineering-SoMoX
     - Palladio-ReverseEngineering-SoMoX-SEFF
@@ -1130,7 +1131,7 @@ jobs:
           "PalladioSimulator/Palladio-QuAL-MonitorRepository", "PalladioSimulator/Palladio-QuAL-ProbeFramework",
           "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-QuAL-SensorFramework",
           "PalladioSimulator/Palladio-ReverseEngineering-Retriever", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Services",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Vulnerability",
+          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Vulnerability",
           "PalladioSimulator/Palladio-ReverseEngineering-SoMoX", "PalladioSimulator/Palladio-ReverseEngineering-SoMoX-SEFF",
           "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Simulation-Scheduler",
           "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-EMFProfilesEditor",
@@ -1143,7 +1144,7 @@ jobs:
         ]] && echo "-f") PalladioSimulator Palladio-Build-UpdateSite build.yml
   Palladio-Core-Commons:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1158,7 +1159,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Core-Commons build.yml
   Palladio-Core-PCM:
@@ -1166,7 +1167,7 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1182,7 +1183,7 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
-          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Core-PCM build.yml
   Palladio-Editors-Commons:
@@ -1191,7 +1192,7 @@ jobs:
     - Palladio-Core-PCM
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1208,7 +1209,7 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-QuAL-EDP2", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Editors-Commons build.yml
   Palladio-Editors-GMF:
@@ -1216,7 +1217,7 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1232,7 +1233,7 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Editors-GMF build.yml
   Palladio-Editors-Sirius:
@@ -1242,7 +1243,7 @@ jobs:
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
     - Palladio-Example-Models-Package
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
     - Palladio-ThirdParty-EMFProfiles
     - Palladio-ThirdParty-YakinduStateCharts
@@ -1263,7 +1264,7 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Addon-ArchitecturalTemplates",
           "PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-Example-Models-Package",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-Supporting-MDSDProfiles",
           "PalladioSimulator/Palladio-ThirdParty-EMFProfiles", "PalladioSimulator/Palladio-ThirdParty-YakinduStateCharts"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Editors-Sirius build.yml
@@ -1274,7 +1275,7 @@ jobs:
     - Palladio-Editors-Commons
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-Supporting-MDSDProfiles
     - set-force-build
     if: success() || failure()
@@ -1292,14 +1293,14 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
-          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-Supporting-MDSDProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Editors-Tree build.yml
   Palladio-Example-Models-Package:
     needs:
     - Palladio-Addon-ArchitecturalTemplates
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1315,7 +1316,7 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Addon-ArchitecturalTemplates",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Example-Models-Package build.yml
   Palladio-QuAL-EDP2:
@@ -1323,7 +1324,7 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - Palladio-ThirdParty-Wrapper
     - set-force-build
@@ -1341,7 +1342,7 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-MeasurementFramework",
-          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+          "PalladioSimulator/Palladio-QuAL-MetricSpecification", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-EDP2 build.yml
@@ -1352,7 +1353,7 @@ jobs:
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-RecorderFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1370,7 +1371,7 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+          "PalladioSimulator/Palladio-QuAL-RecorderFramework", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-ExperimentAnalysis build.yml
@@ -1378,7 +1379,7 @@ jobs:
     needs:
     - Palladio-Core-Commons
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1395,13 +1396,13 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Library"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-MeasurementFramework build.yml
   Palladio-QuAL-MetricSpecification:
     needs:
     - Palladio-Core-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1417,7 +1418,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-MetricSpecification build.yml
@@ -1429,7 +1430,7 @@ jobs:
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1448,7 +1449,7 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
           "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Library"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-MonitorRepository build.yml
   Palladio-QuAL-ProbeFramework:
@@ -1457,7 +1458,7 @@ jobs:
     - Palladio-QuAL-EDP2
     - Palladio-QuAL-MeasurementFramework
     - Palladio-QuAL-MetricSpecification
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1475,7 +1476,7 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Library"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-ProbeFramework build.yml
   Palladio-QuAL-RecorderFramework:
@@ -1486,7 +1487,7 @@ jobs:
     - Palladio-QuAL-MetricSpecification
     - Palladio-QuAL-ProbeFramework
     - Palladio-QuAL-SensorFramework
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1505,13 +1506,13 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-QuAL-EDP2",
           "PalladioSimulator/Palladio-QuAL-MeasurementFramework", "PalladioSimulator/Palladio-QuAL-MetricSpecification",
           "PalladioSimulator/Palladio-QuAL-ProbeFramework", "PalladioSimulator/Palladio-QuAL-SensorFramework",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-ThirdParty-Library"]'
+          "PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-RecorderFramework build.yml
   Palladio-QuAL-SensorFramework:
     needs:
     - Palladio-Core-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Wrapper
     - set-force-build
     if: success() || failure()
@@ -1527,7 +1528,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-QuAL-SensorFramework build.yml
@@ -1538,7 +1539,9 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-ReverseEngineering-Retriever-Services
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-ReverseEngineering-SoMoX-SEFF
+    - Palladio-Supporting-WorkflowEngine
+    - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1556,13 +1559,14 @@ jobs:
         DEPENDENCIES: '["PalladioSimulator/Palladio-Addons-FluentApiModelGenerator",
           "PalladioSimulator/Palladio-Addons-PlantUML", "PalladioSimulator/Palladio-Core-Commons",
           "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Services",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+          "PalladioSimulator/Palladio-ReverseEngineering-SoMoX-SEFF", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-Retriever build.yml
   Palladio-ReverseEngineering-Retriever-Services:
     needs:
     - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-WorkflowEngine
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1577,11 +1581,134 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-Retriever-Services
         build.yml
-  Palladio-ReverseEngineering-Retriever-UpdateSite:
+  Palladio-ReverseEngineering-Retriever-Vulnerability:
+    needs:
+    - Palladio-Addons-Vulnerability-Metamodel
+    - Palladio-Core-PCM
+    - Palladio-ReverseEngineering-Retriever-Services
+    - Palladio-Supporting-WorkflowEngine
+    - set-force-build
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Run remote workflow
+      env:
+        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Addons-Vulnerability-Metamodel",
+          "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Services",
+          "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
+      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
+        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-Retriever-Vulnerability
+        build.yml
+  Palladio-ReverseEngineering-SoMoX:
+    needs:
+    - Palladio-Core-Commons
+    - Palladio-Core-PCM
+    - Palladio-Editors-Commons
+    - Palladio-Supporting-WorkflowEngine
+    - Palladio-ThirdParty-Library
+    - set-force-build
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Run remote workflow
+      env:
+        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
+          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-Supporting-WorkflowEngine",
+          "PalladioSimulator/Palladio-ThirdParty-Library"]'
+      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
+        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-SoMoX build.yml
+  Palladio-ReverseEngineering-SoMoX-SEFF:
+    needs:
+    - Palladio-Addons-FluentApiModelGenerator
+    - Palladio-Core-PCM
+    - Palladio-Supporting-WorkflowEngine
+    - set-force-build
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Run remote workflow
+      env:
+        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Addons-FluentApiModelGenerator",
+          "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-Supporting-WorkflowEngine"]'
+      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
+        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-SoMoX-SEFF
+        build.yml
+  Palladio-Simulation-AbstractSimEngine:
+    needs:
+    - Palladio-Supporting-Branding
+    - Palladio-ThirdParty-Library
+    - Palladio-ThirdParty-Wrapper
+    - set-force-build
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Run remote workflow
+      env:
+        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library",
+          "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
+      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
+        ]] && echo "-f") PalladioSimulator Palladio-Simulation-AbstractSimEngine build.yml
+  Palladio-Simulation-Scheduler:
+    needs:
+    - Palladio-Core-Commons
+    - Palladio-Core-PCM
+    - Palladio-Simulation-AbstractSimEngine
+    - Palladio-Supporting-Branding
+    - set-force-build
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Run remote workflow
+      env:
+        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
+          "PalladioSimulator/Palladio-Simulation-AbstractSimEngine", "PalladioSimulator/Palladio-Supporting-Branding"]'
+      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
+        ]] && echo "-f") PalladioSimulator Palladio-Simulation-Scheduler build.yml
+  Palladio-Supporting-Branding:
     needs:
     - set-force-build
     if: success() || failure()
@@ -1599,154 +1726,9 @@ jobs:
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '[]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-Retriever-UpdateSite
-        build.yml
-  Palladio-ReverseEngineering-Retriever-Vulnerability:
-    needs:
-    - Palladio-Addons-Vulnerability-Metamodel
-    - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-Services
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Addons-Vulnerability-Metamodel",
-          "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-Services",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-Retriever-Vulnerability
-        build.yml
-  Palladio-ReverseEngineering-SoMoX:
-    needs:
-    - Palladio-Core-Commons
-    - Palladio-Core-PCM
-    - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - Palladio-ThirdParty-Library
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-Library"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-SoMoX build.yml
-  Palladio-ReverseEngineering-SoMoX-SEFF:
-    needs:
-    - Palladio-Addons-FluentApiModelGenerator
-    - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Addons-FluentApiModelGenerator",
-          "PalladioSimulator/Palladio-Core-PCM", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-ReverseEngineering-SoMoX-SEFF
-        build.yml
-  Palladio-Simulation-AbstractSimEngine:
-    needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - Palladio-ThirdParty-Library
-    - Palladio-ThirdParty-Wrapper
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-Library", "PalladioSimulator/Palladio-ThirdParty-Wrapper"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-Simulation-AbstractSimEngine build.yml
-  Palladio-Simulation-Scheduler:
-    needs:
-    - Palladio-Core-Commons
-    - Palladio-Core-PCM
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - Palladio-Simulation-AbstractSimEngine
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite", "PalladioSimulator/Palladio-Simulation-AbstractSimEngine"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
-        ]] && echo "-f") PalladioSimulator Palladio-Simulation-Scheduler build.yml
-  Palladio-Supporting-Branding:
-    needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
-    - set-force-build
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Run remote workflow
-      env:
-        GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-        FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
-      run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Supporting-Branding build.yml
   Palladio-Supporting-EMFProfilesEditor:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-ThirdParty-EMFProfiles
     - set-force-build
     if: success() || failure()
@@ -1762,14 +1744,12 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Supporting-EMFProfilesEditor build.yml
   Palladio-Supporting-FeatureModel:
     needs:
     - Palladio-Core-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1784,13 +1764,13 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Supporting-FeatureModel build.yml
   Palladio-Supporting-MDSDProfiles:
     needs:
     - Palladio-Core-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-EMFProfiles
     - set-force-build
     if: success() || failure()
@@ -1806,14 +1786,14 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Supporting-Branding",
           "PalladioSimulator/Palladio-ThirdParty-EMFProfiles"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Supporting-MDSDProfiles build.yml
   Palladio-Supporting-WorkflowEngine:
     needs:
     - Palladio-Core-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1828,7 +1808,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Supporting-Branding"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-Supporting-WorkflowEngine build.yml
   Palladio-ThirdParty-CloudScaleUsageEvolution:
@@ -1836,7 +1816,6 @@ jobs:
     - Palladio-Core-Commons
     - Palladio-Core-PCM
     - Palladio-Editors-Commons
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - Palladio-ThirdParty-LIMBO
     - set-force-build
     if: success() || failure()
@@ -1853,14 +1832,12 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
         DEPENDENCIES: '["PalladioSimulator/Palladio-Core-Commons", "PalladioSimulator/Palladio-Core-PCM",
-          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-LIMBO"]'
+          "PalladioSimulator/Palladio-Editors-Commons", "PalladioSimulator/Palladio-ThirdParty-LIMBO"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-CloudScaleUsageEvolution
         build.yml
   Palladio-ThirdParty-EMFProfiles:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1875,12 +1852,12 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '[]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-EMFProfiles build.yml
   Palladio-ThirdParty-LIMBO:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1896,8 +1873,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-Library"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-LIMBO build.yml
   Palladio-ThirdParty-Library:
@@ -1921,7 +1897,7 @@ jobs:
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-Library build.yml
   Palladio-ThirdParty-Wrapper:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
+    - Palladio-Supporting-Branding
     - Palladio-ThirdParty-Library
     - set-force-build
     if: success() || failure()
@@ -1937,13 +1913,11 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite",
-          "PalladioSimulator/Palladio-ThirdParty-Library"]'
+        DEPENDENCIES: '["PalladioSimulator/Palladio-Supporting-Branding", "PalladioSimulator/Palladio-ThirdParty-Library"]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-Wrapper build.yml
   Palladio-ThirdParty-YakinduStateCharts:
     needs:
-    - Palladio-ReverseEngineering-Retriever-UpdateSite
     - set-force-build
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -1958,7 +1932,7 @@ jobs:
       env:
         GITHUB_OAUTH: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         FORCE_BUILD: ${{needs.set-force-build.outputs.force_build}}
-        DEPENDENCIES: '["PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite"]'
+        DEPENDENCIES: '[]'
       run: python scripts/dispatch_workflow.py $([[ "${{ env.FORCE_BUILD }}" == 'true'
         ]] && echo "-f") PalladioSimulator Palladio-ThirdParty-YakinduStateCharts
         build.yml

--- a/.github/workflows/update_build.yml
+++ b/.github/workflows/update_build.yml
@@ -27,7 +27,7 @@ jobs:
         run: mvn -DskipTests clean package
       - name: Run Palladio-Build-DependencyTool
         id: dependencyTool
-        run: echo "DEPENDENCIES=$(java -jar target/deploy/dependencytool.jar -ri Palladio-Build-UpdateSite -ii -us 'https://updatesite.palladio-simulator.com/' -rrf .github/workflows/build.yml -j -o dependencies PalladioSimulator)" >> "$GITHUB_OUTPUT"
+        run: echo "DEPENDENCIES=$(java -jar target/deploy/dependencytool.jar -ri Palladio-Build-UpdateSite,Palladio-ReverseEngineering-Retriever-UpdateSite -ii -us 'https://updatesite.palladio-simulator.com/' -rrf .github/workflows/build.yml -j -o dependencies PalladioSimulator)" >> "$GITHUB_OUTPUT"
 
   generateNightlyBuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Problem
The dependency graph currently shows false dependencies. Because the [`Retriever-UpdateSite`](https://github.com/PalladioSimulator/Palladio-ReverseEngineering-Retriever-UpdateSite) acts as an aggregator, the [`DependencyTool`](https://github.com/PalladioSimulator/Palladio-Build-DependencyTool) mistakenly identifies it as the original provider for all its bundled dependencies. As a result, dependencies for various repositories (e.g., [`WorkflowEngine`](https://github.com/PalladioSimulator/Palladio-Supporting-WorkflowEngine) or [`Branding`](https://github.com/PalladioSimulator/Palladio-Supporting-Branding)) incorrectly point to the `Retriever-UpdateSite`.

### Solution
Add `Palladio-ReverseEngineering-Retriever-UpdateSite` to the ignore list (`-ri`) in[`.github/workflows/update_build.yml`](https://github.com/PalladioSimulator/Palladio-Build-Nightly/blob/master/.github/workflows/update_build.yml).

### Result
**Correct source resolution:** All repositories are now correctly mapped to their actual source repositories.